### PR TITLE
#5対応

### DIFF
--- a/app/src/main/java/org/nunocky/weatherapi_flux_study01/action/ActionCreator.kt
+++ b/app/src/main/java/org/nunocky/weatherapi_flux_study01/action/ActionCreator.kt
@@ -23,11 +23,15 @@ class ActionCreator(private val dispatcher: Dispatcher) : CoroutineScope {
                 instance = ActionCreator(dispatcher)
             }
 
+            if (instance!!.job.isCancelled) {
+                instance!!.job = Job()
+            }
+
             return instance!!
         }
     }
 
-    private val job = Job()
+    var job = Job()
 
     override val coroutineContext: CoroutineContext
         get() = Dispatchers.Main + job


### PR DESCRIPTION
復帰時、ActionCreator(Singleton)のJobがキャンセルされていたら新規に作成する